### PR TITLE
chore: jwt: SAST (sonar) Fixes

### DIFF
--- a/src/main/java/org/zaproxy/zap/extension/jwt/JWTActiveScanRule.java
+++ b/src/main/java/org/zaproxy/zap/extension/jwt/JWTActiveScanRule.java
@@ -50,8 +50,6 @@ public class JWTActiveScanRule extends AbstractAppParamPlugin {
     private static final Logger LOGGER = Logger.getLogger(JWTActiveScanRule.class);
     private int maxRequestCount;
 
-    public JWTActiveScanRule() {}
-
     @Override
     public void init() {
         switch (this.getAttackStrength()) {

--- a/src/main/java/org/zaproxy/zap/extension/jwt/JWTConfiguration.java
+++ b/src/main/java/org/zaproxy/zap/extension/jwt/JWTConfiguration.java
@@ -29,7 +29,7 @@ import org.zaproxy.zap.extension.jwt.utils.JWTUtils;
  */
 public class JWTConfiguration extends VersionedAbstractParam {
 
-    protected static final Logger LOGGER = Logger.getLogger(JWTExtension.class);
+    protected static final Logger LOGGER = Logger.getLogger(JWTConfiguration.class);
 
     /** The base configuration key for all JWT configurations. */
     private static final String PARAM_BASE_KEY = "jwt";
@@ -71,9 +71,9 @@ public class JWTConfiguration extends VersionedAbstractParam {
     private void init() {
         FILE_NAMES_CONTAINING_PUBLICLY_KNOWN_HMAC_SECRETS.stream()
                 .forEach(
-                        (fileName) -> {
+                        fileName -> {
                             Set<String> values = JWTUtils.readFileContentsFromResources(fileName);
-                            if (values != null && values.size() != 0) {
+                            if (values != null && !values.isEmpty()) {
                                 publiclyKnownHMacSecrets.addAll(values);
                             }
                         });

--- a/src/main/java/org/zaproxy/zap/extension/jwt/JWTExtension.java
+++ b/src/main/java/org/zaproxy/zap/extension/jwt/JWTExtension.java
@@ -21,7 +21,6 @@ import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.extension.Extension;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
-import org.parosproxy.paros.extension.ViewDelegate;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.extension.fuzz.ExtensionFuzz;
 import org.zaproxy.zap.extension.fuzz.MessagePanelManager;
@@ -68,11 +67,6 @@ public class JWTExtension extends ExtensionAdaptor {
         jwtMessageLocationReplacerFactory = new JWTMessageLocationReplacerFactory();
         MessageLocationReplacers.getInstance()
                 .addReplacer(HttpMessage.class, jwtMessageLocationReplacerFactory);
-    }
-
-    @Override
-    public void initView(ViewDelegate view) {
-        super.initView(view);
     }
 
     @Override

--- a/src/main/java/org/zaproxy/zap/extension/jwt/JWTHolder.java
+++ b/src/main/java/org/zaproxy/zap/extension/jwt/JWTHolder.java
@@ -78,8 +78,7 @@ public class JWTHolder {
     /** @return algorithm value from Header */
     public String getAlgorithm() {
         JSONObject headerJSONObject = new JSONObject(this.getHeader());
-        String algoType = headerJSONObject.getString(JWT_ALGORITHM_KEY_HEADER);
-        return algoType;
+        return headerJSONObject.getString(JWT_ALGORITHM_KEY_HEADER);
     }
 
     /**

--- a/src/main/java/org/zaproxy/zap/extension/jwt/JWTI18n.java
+++ b/src/main/java/org/zaproxy/zap/extension/jwt/JWTI18n.java
@@ -22,8 +22,12 @@ import org.parosproxy.paros.Constant;
  * @author KSASAN preetkaran20@gmail.com
  * @since TODO add version
  */
-public class JWTI18n {
+public final class JWTI18n {
     private static ResourceBundle message;
+
+    private JWTI18n() {
+        // Nothing to do.
+    }
 
     public static void init() {
         message =

--- a/src/main/java/org/zaproxy/zap/extension/jwt/attacks/SignatureAttack.java
+++ b/src/main/java/org/zaproxy/zap/extension/jwt/attacks/SignatureAttack.java
@@ -150,7 +150,7 @@ public class SignatureAttack implements JWTAttack {
      *
      * @throws JWTException
      */
-    private boolean executeNullByteAttack() throws JWTException {
+    private boolean executeNullByteAttack() {
         // Appends signature with NullByte plus ZAP eyeCather.
         JWTHolder cloneJWTHolder = new JWTHolder(this.serverSideAttack.getJwtHolder());
         if (this.serverSideAttack.getJwtActiveScanRule().isStop()) {
@@ -348,7 +348,7 @@ public class SignatureAttack implements JWTAttack {
                 | NoSuchAlgorithmException
                 | CertificateException
                 | IOException e) {
-            new JWTException(
+            throw new JWTException(
                     "An exception occurred while getting manipulated token for confusion scenario",
                     e);
         }

--- a/src/main/java/org/zaproxy/zap/extension/jwt/fuzzer/messagelocations/FuzzerJWTSignatureOperation.java
+++ b/src/main/java/org/zaproxy/zap/extension/jwt/fuzzer/messagelocations/FuzzerJWTSignatureOperation.java
@@ -47,6 +47,7 @@ public enum FuzzerJWTSignatureOperation {
         this.labelKey = labelKey;
     }
 
+    @Override
     public String toString() {
         return JWTI18n.getResourceBundle().getString(labelKey);
     }

--- a/src/main/java/org/zaproxy/zap/extension/jwt/fuzzer/messagelocations/JWTMessageLocation.java
+++ b/src/main/java/org/zaproxy/zap/extension/jwt/fuzzer/messagelocations/JWTMessageLocation.java
@@ -140,10 +140,6 @@ public class JWTMessageLocation extends DefaultTextHttpMessageLocation implement
         if (result != 0) {
             return result;
         }
-
-        if (result != 0) {
-            return result;
-        }
         return super.compareTo(otherLocation);
     }
 

--- a/src/main/java/org/zaproxy/zap/extension/jwt/fuzzer/ui/GenericCriteriaBasedMessageLocationProducerFocusListenerAdapter.java
+++ b/src/main/java/org/zaproxy/zap/extension/jwt/fuzzer/ui/GenericCriteriaBasedMessageLocationProducerFocusListenerAdapter.java
@@ -39,7 +39,7 @@ public class GenericCriteriaBasedMessageLocationProducerFocusListenerAdapter
 
     @Override
     public void focusGained(FocusEvent e) {
-        if (!this.criteriaSupplier.get()) {
+        if (Boolean.FALSE.equals(this.criteriaSupplier.get())) {
             return;
         }
         super.focusGained(e);

--- a/src/main/java/org/zaproxy/zap/extension/jwt/fuzzer/ui/JWTFuzzPanelView.java
+++ b/src/main/java/org/zaproxy/zap/extension/jwt/fuzzer/ui/JWTFuzzPanelView.java
@@ -16,7 +16,6 @@ package org.zaproxy.zap.extension.jwt.fuzzer.ui;
 import java.awt.Component;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
-import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -33,6 +32,7 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.ScrollPaneConstants;
+import javax.swing.SwingConstants;
 import org.apache.commons.configuration.FileConfiguration;
 import org.apache.log4j.Logger;
 import org.json.JSONObject;
@@ -87,8 +87,7 @@ public class JWTFuzzPanelView
 
     private GridBagConstraints gridBagConstraints;
     private Vector<String> jwtComboBoxModel =
-            new Vector<String>(
-                    Arrays.asList(JWTI18n.getMessage("jwt.fuzzer.panel.jwtcombobox.select")));
+            new Vector<>(Arrays.asList(JWTI18n.getMessage("jwt.fuzzer.panel.jwtcombobox.select")));
     private HttpMessage message;
     private Map<String, String> comboBoxKeyAndJwtMap = new HashMap<>();
     private Map<JWTMessageLocation, List<Component>> jwtMessageLocationAndRelatedComponentsMap =
@@ -118,32 +117,30 @@ public class JWTFuzzPanelView
         commonPropertiesPanel.setLayout(gridBagLayout);
         commonPropertiesPanel.setBorder(
                 JWTUIUtils.getTitledBorder("jwt.fuzzer.panel.commonConfiguration"));
-        GridBagConstraints gridBagConstraints = JWTUIUtils.getGridBagConstraints();
-        gridBagConstraints.gridx = 0;
+        GridBagConstraints gbc = JWTUIUtils.getGridBagConstraints();
+        gbc.gridx = 0;
         commonPropertiesPanel.add(
-                new JLabel(JWTI18n.getMessage("jwt.settings.title"), JLabel.CENTER),
-                gridBagConstraints);
-        gridBagConstraints.gridx++;
+                new JLabel(JWTI18n.getMessage("jwt.settings.title"), SwingConstants.CENTER), gbc);
+        gbc.gridx++;
         commonPropertiesPanel.add(
                 new JLabel(
                         JWTI18n.getMessage("jwt.fuzzer.panel.signature.operationtype"),
-                        JLabel.CENTER),
-                gridBagConstraints);
-        gridBagConstraints.gridx = 0;
-        gridBagConstraints.gridy++;
-        jwtComboBox = new JComboBox<String>(this.jwtComboBoxModel);
-        commonPropertiesPanel.add(jwtComboBox, gridBagConstraints);
-        gridBagConstraints.gridx++;
-        jwtSignatureOperationCheckBox =
-                new JComboBox<FuzzerJWTSignatureOperation>(FuzzerJWTSignatureOperation.values());
-        commonPropertiesPanel.add(jwtSignatureOperationCheckBox, gridBagConstraints);
+                        SwingConstants.CENTER),
+                gbc);
+        gbc.gridx = 0;
+        gbc.gridy++;
+        jwtComboBox = new JComboBox<>(this.jwtComboBoxModel);
+        commonPropertiesPanel.add(jwtComboBox, gbc);
+        gbc.gridx++;
+        jwtSignatureOperationCheckBox = new JComboBox<>(FuzzerJWTSignatureOperation.values());
+        commonPropertiesPanel.add(jwtSignatureOperationCheckBox, gbc);
         this.addActionListenerToRequestFocus(this.jwtComboBox);
         this.addActionListenerToRequestFocus(this.jwtSignatureOperationCheckBox);
         return commonPropertiesPanel;
     }
 
     private <T> void addActionListenerToRequestFocus(JComboBox<T> comboBox) {
-        comboBox.addActionListener((e) -> contentPanel.requestFocusInWindow());
+        comboBox.addActionListener(e -> contentPanel.requestFocusInWindow());
     }
 
     private JPanel getFuzzerPanel() {
@@ -154,11 +151,13 @@ public class JWTFuzzPanelView
         fuzzerPanel.setLayout(gridBagLayout);
 
         JLabel componentLabel =
-                new JLabel(JWTI18n.getMessage("jwt.fuzzer.panel.token.component"), JLabel.CENTER);
+                new JLabel(
+                        JWTI18n.getMessage("jwt.fuzzer.panel.token.component"),
+                        SwingConstants.CENTER);
         fuzzerPanel.add(componentLabel, gridBagConstraints);
         gridBagConstraints.gridx++;
         JLabel keyLabel =
-                new JLabel(JWTI18n.getMessage("jwt.fuzzer.panel.token.key"), JLabel.CENTER);
+                new JLabel(JWTI18n.getMessage("jwt.fuzzer.panel.token.key"), SwingConstants.CENTER);
         fuzzerPanel.add(keyLabel, gridBagConstraints);
 
         gridBagConstraints.gridy++;
@@ -168,8 +167,8 @@ public class JWTFuzzPanelView
 
     private void updateUIWithJWTSelection() {
         if (jwtComboBox.getSelectedIndex() > 0) {
-            jwtComponentType = new JComboBox<String>();
-            jwtComponentJsonKeysComboBox = new JComboBox<String>();
+            jwtComponentType = new JComboBox<>();
+            jwtComponentJsonKeysComboBox = new JComboBox<>();
             this.addActionListenerToRequestFocus(jwtComponentType);
             this.addActionListenerToRequestFocus(jwtComponentJsonKeysComboBox);
             String selectedItem =
@@ -220,7 +219,7 @@ public class JWTFuzzPanelView
     }
 
     private ActionListener getJWTComponentTypeActionListener(JWTHolder jwtHolder) {
-        return (e) -> {
+        return e -> {
             String jwtComponentValue = jwtHolder.getHeader();
             if (jwtComponentType.getSelectedIndex() == 1) {
                 jwtComponentValue = jwtHolder.getPayload();
@@ -237,13 +236,7 @@ public class JWTFuzzPanelView
     }
 
     private void addActionListenerOnJWTComboBox() {
-        jwtComboBox.addActionListener(
-                new ActionListener() {
-                    @Override
-                    public void actionPerformed(ActionEvent actionEvent) {
-                        updateUIWithJWTSelection();
-                    }
-                });
+        jwtComboBox.addActionListener(e -> updateUIWithJWTSelection());
     }
 
     /** Adds the New JWT Component Type and Key Field ComboBox. */
@@ -383,17 +376,14 @@ public class JWTFuzzPanelView
             location = Location.REQUEST_BODY;
             startIndex = this.message.getRequestBody().toString().indexOf(jwt);
         }
-        JWTMessageLocation jwtMessageLocation =
-                new JWTMessageLocation(
-                        location,
-                        startIndex,
-                        startIndex + jwt.length(),
-                        jwt,
-                        jwtComponentJsonKey,
-                        isHeaderComponent,
-                        (FuzzerJWTSignatureOperation)
-                                (jwtSignatureOperationCheckBox.getSelectedItem()));
-        return jwtMessageLocation;
+        return new JWTMessageLocation(
+                location,
+                startIndex,
+                startIndex + jwt.length(),
+                jwt,
+                jwtComponentJsonKey,
+                isHeaderComponent,
+                (FuzzerJWTSignatureOperation) (jwtSignatureOperationCheckBox.getSelectedItem()));
     }
 
     private Supplier<Boolean> getFocusListenerCriteria() {
@@ -478,7 +468,7 @@ public class JWTFuzzPanelView
                 Arrays.asList(this.jwtComponentType, this.jwtComponentJsonKeysComboBox);
         this.jwtMessageLocationAndRelatedComponentsMap.put(
                 (JWTMessageLocation) location, components);
-        components.forEach((component) -> component.setEnabled(false));
+        components.forEach(component -> component.setEnabled(false));
         addNewFuzzerFieldsRow();
         if (jwtMessageLocationAndRelatedComponentsMap.size() > 0) {
             this.jwtComboBox.setEnabled(false);
@@ -493,9 +483,9 @@ public class JWTFuzzPanelView
         if (jwtMessageLocationAndRelatedComponentsMap.containsKey(location)) {
             this.jwtMessageLocationAndRelatedComponentsMap
                     .get(location)
-                    .forEach((component) -> fuzzerPanel.remove(component));
+                    .forEach(component -> fuzzerPanel.remove(component));
         }
-        this.jwtMessageLocationAndRelatedComponentsMap.remove((JWTMessageLocation) location);
+        this.jwtMessageLocationAndRelatedComponentsMap.remove(location);
         if (jwtMessageLocationAndRelatedComponentsMap.size() == 0) {
             this.jwtComboBox.setEnabled(true);
             this.jwtSignatureOperationCheckBox.setEnabled(true);

--- a/src/main/java/org/zaproxy/zap/extension/jwt/ui/JWTOptionsPanel.java
+++ b/src/main/java/org/zaproxy/zap/extension/jwt/ui/JWTOptionsPanel.java
@@ -17,8 +17,6 @@ import java.awt.BorderLayout;
 import java.awt.FlowLayout;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.awt.event.FocusEvent;
 import java.awt.event.FocusListener;
 import java.io.File;
@@ -102,13 +100,7 @@ public class JWTOptionsPanel extends AbstractParamPanel {
     private JButton getResetButton() {
         JButton resetButton = new JButton();
         resetButton.setText(JWTI18n.getMessage("jwt.settings.button.reset"));
-        resetButton.addActionListener(
-                new ActionListener() {
-                    @Override
-                    public void actionPerformed(ActionEvent e) {
-                        resetOptionsPanel();
-                    }
-                });
+        resetButton.addActionListener(e -> resetOptionsPanel());
         return resetButton;
     }
 
@@ -117,39 +109,34 @@ public class JWTOptionsPanel extends AbstractParamPanel {
         trustStoreFileChooserButton =
                 new JButton(JWTI18n.getMessage("jwt.settings.filechooser.button"));
         trustStoreFileChooserButton.addActionListener(
-                new ActionListener() {
+                e -> {
+                    trustStoreFileChooser = new JFileChooser();
+                    trustStoreFileChooser.setFileFilter(
+                            new FileFilter() {
 
-                    @Override
-                    public void actionPerformed(ActionEvent e) {
-                        trustStoreFileChooser = new JFileChooser();
-                        trustStoreFileChooser.setFileFilter(
-                                new FileFilter() {
+                                @Override
+                                public String getDescription() {
+                                    return JWTI18n.getMessage(
+                                            "jwt.settings.rsa.trustStoreFileDescription");
+                                }
 
-                                    @Override
-                                    public String getDescription() {
-                                        return JWTI18n.getMessage(
-                                                "jwt.settings.rsa.trustStoreFileDescription");
-                                    }
-
-                                    @Override
-                                    public boolean accept(File f) {
-                                        return f.getName().endsWith(".p12") || f.isDirectory();
-                                    }
-                                });
-                        trustStoreFileChooser.setFileSelectionMode(JFileChooser.FILES_ONLY);
-                        String path = trustStoreFileChooserTextField.getText();
-                        if (!path.isEmpty()) {
-                            File file = new File(path);
-                            if (file.exists()) {
-                                trustStoreFileChooser.setSelectedFile(file);
-                            }
+                                @Override
+                                public boolean accept(File f) {
+                                    return f.getName().endsWith(".p12") || f.isDirectory();
+                                }
+                            });
+                    trustStoreFileChooser.setFileSelectionMode(JFileChooser.FILES_ONLY);
+                    String path = trustStoreFileChooserTextField.getText();
+                    if (!path.isEmpty()) {
+                        File file = new File(path);
+                        if (file.exists()) {
+                            trustStoreFileChooser.setSelectedFile(file);
                         }
-                        if (trustStoreFileChooser.showOpenDialog(null)
-                                == JFileChooser.APPROVE_OPTION) {
-                            final File selectedFile = trustStoreFileChooser.getSelectedFile();
-                            trustStorePath = selectedFile.getAbsolutePath();
-                            trustStoreFileChooserTextField.setText(selectedFile.getAbsolutePath());
-                        }
+                    }
+                    if (trustStoreFileChooser.showOpenDialog(null) == JFileChooser.APPROVE_OPTION) {
+                        final File selectedFile = trustStoreFileChooser.getSelectedFile();
+                        trustStorePath = selectedFile.getAbsolutePath();
+                        trustStoreFileChooserTextField.setText(selectedFile.getAbsolutePath());
                     }
                 });
     }
@@ -267,40 +254,36 @@ public class JWTOptionsPanel extends AbstractParamPanel {
         jwtRsaPrivateKeyFileChooserTextField.setEditable(false);
         jwtRsaPrivateKeyFileChooserTextField.setColumns(15);
         jwtRsaPrivateKeyFileChooserButton.addActionListener(
-                new ActionListener() {
+                e -> {
+                    JFileChooser jwtRsaPrivateKeyFileChooser = new JFileChooser();
+                    jwtRsaPrivateKeyFileChooser.setFileFilter(
+                            new FileFilter() {
 
-                    @Override
-                    public void actionPerformed(ActionEvent e) {
-                        JFileChooser jwtRsaPrivateKeyFileChooser = new JFileChooser();
-                        jwtRsaPrivateKeyFileChooser.setFileFilter(
-                                new FileFilter() {
+                                @Override
+                                public String getDescription() {
+                                    return JWTI18n.getMessage(
+                                            "jwt.settings.rsa.keystore.pemFileDescription");
+                                }
 
-                                    @Override
-                                    public String getDescription() {
-                                        return JWTI18n.getMessage(
-                                                "jwt.settings.rsa.keystore.pemFileDescription");
-                                    }
-
-                                    @Override
-                                    public boolean accept(File f) {
-                                        return f.getName().endsWith(".pem") || f.isDirectory();
-                                    }
-                                });
-                        jwtRsaPrivateKeyFileChooser.setFileSelectionMode(JFileChooser.FILES_ONLY);
-                        String path = jwtRsaPrivateKeyFileChooserTextField.getText();
-                        if (!path.isEmpty()) {
-                            File file = new File(path);
-                            if (file.exists()) {
-                                jwtRsaPrivateKeyFileChooser.setSelectedFile(file);
-                            }
+                                @Override
+                                public boolean accept(File f) {
+                                    return f.getName().endsWith(".pem") || f.isDirectory();
+                                }
+                            });
+                    jwtRsaPrivateKeyFileChooser.setFileSelectionMode(JFileChooser.FILES_ONLY);
+                    String path = jwtRsaPrivateKeyFileChooserTextField.getText();
+                    if (!path.isEmpty()) {
+                        File file = new File(path);
+                        if (file.exists()) {
+                            jwtRsaPrivateKeyFileChooser.setSelectedFile(file);
                         }
-                        if (jwtRsaPrivateKeyFileChooser.showOpenDialog(null)
-                                == JFileChooser.APPROVE_OPTION) {
-                            final File selectedFile = jwtRsaPrivateKeyFileChooser.getSelectedFile();
-                            jwtRsaPrivateKeyFileChooserPath = selectedFile.getAbsolutePath();
-                            jwtRsaPrivateKeyFileChooserTextField.setText(
-                                    selectedFile.getAbsolutePath());
-                        }
+                    }
+                    if (jwtRsaPrivateKeyFileChooser.showOpenDialog(null)
+                            == JFileChooser.APPROVE_OPTION) {
+                        final File selectedFile = jwtRsaPrivateKeyFileChooser.getSelectedFile();
+                        jwtRsaPrivateKeyFileChooserPath = selectedFile.getAbsolutePath();
+                        jwtRsaPrivateKeyFileChooserTextField.setText(
+                                selectedFile.getAbsolutePath());
                     }
                 });
         gridBagConstraints.gridx = 0;

--- a/src/main/java/org/zaproxy/zap/extension/jwt/utils/JWTConstants.java
+++ b/src/main/java/org/zaproxy/zap/extension/jwt/utils/JWTConstants.java
@@ -25,12 +25,13 @@ public interface JWTConstants {
 
     char JWT_TOKEN_PERIOD_CHARACTER = '.';
     String JWT_TOKEN_PERIOD_CHARACTER_REGEX = "[" + JWT_TOKEN_PERIOD_CHARACTER + "]";
+    String JWT_COMPONENT_REGEX = "[a-zA-Z0-9_-]*";
     String JWT_TOKEN_FORMAT_REGEX =
-            "[a-zA-Z0-9_-]*"
+            JWT_COMPONENT_REGEX
                     + JWT_TOKEN_PERIOD_CHARACTER_REGEX
-                    + "[a-zA-Z0-9_-]*"
+                    + JWT_COMPONENT_REGEX
                     + JWT_TOKEN_PERIOD_CHARACTER_REGEX
-                    + "[a-zA-Z0-9_-]*";
+                    + JWT_COMPONENT_REGEX;
     // Pattern JWT_TOKEN_REGEX_VALIDATOR_PATTERN = Pattern.compile(JWT_TOKEN_FORMAT_REGEX + "$");
     Pattern JWT_TOKEN_REGEX_PATTERN = Pattern.compile(JWT_TOKEN_FORMAT_REGEX);
     String BASE64_PADDING_CHARACTER_REGEX = "[=]";
@@ -69,7 +70,7 @@ public interface JWTConstants {
             createJWTHmacAlgoToJavaAlgoMapping();
 
     static Map<String, String> createJWTHmacAlgoToJavaAlgoMapping() {
-        Map<String, String> jwtAlgoToJavaAlgoMapping = new HashMap<String, String>();
+        Map<String, String> jwtAlgoToJavaAlgoMapping = new HashMap<>();
         jwtAlgoToJavaAlgoMapping.put("HS256", "HmacSHA256");
         jwtAlgoToJavaAlgoMapping.put("HS384", "HmacSHA384");
         jwtAlgoToJavaAlgoMapping.put("HS512", "HmacSHA512");

--- a/src/main/java/org/zaproxy/zap/extension/jwt/utils/JWTUIUtils.java
+++ b/src/main/java/org/zaproxy/zap/extension/jwt/utils/JWTUIUtils.java
@@ -24,7 +24,11 @@ import org.zaproxy.zap.utils.FontUtils;
  *
  * @author preetkaran20@gmail.com KSASAN
  */
-public class JWTUIUtils {
+public final class JWTUIUtils {
+
+    private JWTUIUtils() {
+        // Utility class.
+    }
 
     /**
      * Returns the Titled Border with the provided titleKey.

--- a/src/main/java/org/zaproxy/zap/extension/jwt/utils/JWTUtils.java
+++ b/src/main/java/org/zaproxy/zap/extension/jwt/utils/JWTUtils.java
@@ -62,9 +62,13 @@ import org.zaproxy.zap.extension.jwt.exception.JWTException;
  * @author KSASAN preetkaran20@gmail.com
  * @since TODO add version
  */
-public class JWTUtils {
+public final class JWTUtils {
 
     private static final Logger LOGGER = Logger.getLogger(JWTUtils.class);
+
+    private JWTUtils() {
+        // Utility class
+    }
 
     /**
      * Converts string to bytes. This method assumes that token is in UTF-8 charset which is as per


### PR DESCRIPTION
- JWTActiveScanRule > Removed unnecessary constructor.
- JWTConfiguration > Properly create logger. Remove unnecessary brackets, and use isEmpty for Set content check.
- JWTConstants > Create a constant for the component regex. Use diamond operator.
- JWTExtension > Remove overridden method that simply uses a call to the super method anyway.
- JWTFuzzPanelView > Use SwingConstants where applicable. Use lambdas
for anonymous inner classes. Remove unnecessary brackets.
- JWTHolder > Don't use intermediate assignment when returning.
- JWTI18n > Add private constructor to hide the implicit public one.
- JWTMessageLocation > Remove duplicate condition.
- JWTOptionsPanel > Use lambda for anonymous inner class.
- JWTUIUtils > Add private constructor to hide the implicit public one.
- JWTUtils > Add private constructor to hide the implicit public one.
- SignatureAttack > Remove unnecessary throws declaration. Actually throw the constructed exception.

Note this seemed to build fine, but I don't have any kind of testing environment.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>