### PR TITLE
Reduce JWT scan rules false positives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Unreleased
 
+### Changed
+ - Added checks to not raise alerts in CSS, JavaScript or 404 status code pages.
 
 ### [1.0.3] - 2023-01-01
  - Ensure i18n resources are always initialized.

--- a/src/main/java/org/zaproxy/zap/extension/jwt/JWTActiveScanRule.java
+++ b/src/main/java/org/zaproxy/zap/extension/jwt/JWTActiveScanRule.java
@@ -22,6 +22,7 @@ import org.parosproxy.paros.core.scanner.Category;
 import org.parosproxy.paros.core.scanner.NameValuePair;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
+import org.parosproxy.paros.network.HttpStatusCode;
 import org.zaproxy.zap.extension.jwt.attacks.ClientSideAttack;
 import org.zaproxy.zap.extension.jwt.attacks.ServerSideAttack;
 import org.zaproxy.zap.extension.jwt.exception.JWTException;
@@ -214,7 +215,10 @@ public class JWTActiveScanRule extends AbstractAppParamPlugin {
             this.sendAndReceive(newMsg, false);
             if (newMsg.getResponseHeader().getStatusCode()
                             == msg.getResponseHeader().getStatusCode()
-                    && newMsg.getResponseBody().equals(msg.getResponseBody())) {
+                    && newMsg.getResponseBody().equals(msg.getResponseBody())
+                    && !msg.getResponseHeader().isJavaScript()
+                    && !msg.getResponseHeader().isCss()
+                    && msg.getResponseHeader().getStatusCode() != HttpStatusCode.NOT_FOUND) {
                 return true;
             }
         } catch (IOException e) {


### PR DESCRIPTION
This PR tries to reduce false positives for JWT scan rule by adding checks for:
- 404 pages
- CSS files
- JavaScript files

Fixes: https://github.com/SasanLabs/owasp-zap-jwt-addon/issues/42

Signed-off-by: Karthik UJ [karthikuj2001@gmail.com](mailto:karthikuj2001@gmail.com)