### PR TITLE
Added yaml file for checking the ChangeLog file during PR

### DIFF
--- a/.github/workflows/changelog-checker.yml
+++ b/.github/workflows/changelog-checker.yml
@@ -1,0 +1,27 @@
+name: Changelog Check
+on:
+  push:
+    branches:
+      - githubaction_pr_check
+  pull_request:
+    types: [assigned, opened, synchronize, reopened, labeled, unlabeled]
+    branches:
+      - master
+      - develop
+jobs:
+  build:
+    name: Check Actions
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check for changelog updates
+        uses: Zomzog/changelog-checker@v1.2.0
+        with:
+          fileName: CHANGELOG.md # default `CHANGELOG.adoc`
+          noChangelogLabel: "no changelog" # default `no changelog`
+          checkNotification: Simple # default `Detailed`
+
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Again raising the PR due to issues with other 2 PRS; #47 #48 

This PR adds a GitHub Action to ensure CHANGELOG.md is updated before merging a PR. It prevents accidental merges without changelog updates and improves documentation consistency.

Key Changes:

Integrated Zomzog/changelog-checker@v1.2.0.
PRs fail if CHANGELOG.md is not modified.
Allows bypassing with the "no changelog" label.
Closes https://github.com/SasanLabs/owasp-zap-jwt-addon/issues/18